### PR TITLE
4 ajustar makefile com estrutura antiga

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Variáveis
-BINARY_DIR := dist
+REPO_BIN_DIR := dist
 CMD_DIR := ./cmd
 INTERNAL_PKG := dev-metrics/internal/metrics
 
 # Instalação (sem sudo)
 PREFIX ?= $(HOME)/.local
-INSTALLBINDIR ?= $(PREFIX)/bin
+BIN_DIR ?= $(PREFIX)/bin
 INSTALL ?= install
 
 # Nomes dos binários
@@ -30,38 +30,38 @@ all: setup build
 
 # Cria a pasta dist se não existir
 setup:
-	@mkdir -p $(BINARY_DIR)
+	@mkdir -p $(REPO_BIN_DIR)
 
 # Compila os dois binários
 build: setup
 	@echo "Compilando $(BMT)..."
-	go build -ldflags="$(LDFLAGS)" -o $(BINARY_DIR)/$(BMT) $(CMD_DIR)/$(BMT)
+	go build -ldflags="$(LDFLAGS)" -o $(REPO_BIN_DIR)/$(BMT) $(CMD_DIR)/$(BMT)
 	
-	@echo "Build concluído! Binários disponíveis em ./$(BINARY_DIR)"
+	@echo "Build concluído! Binários disponíveis em ./$(REPO_BIN_DIR)"
 
 # Remove a pasta dist
 clean:
 	@echo "Limpando arquivos..."
-	rm -rf $(BINARY_DIR)
-	@echo "Pasta $(BINARY_DIR) removida."
+	rm -rf $(REPO_BIN_DIR)
+	@echo "Pasta $(REPO_BIN_DIR) removida."
 
 # Atalho para rodar o build-meter (exemplo)
 # Use como: make run ARGS="cmake --version"
 run: build
-	./$(BINARY_DIR)/$(BMT) $(ARGS)
+	./$(REPO_BIN_DIR)/$(BMT) $(ARGS)
 
 install: build
-	@echo "Instalando binários em $(INSTALLBINDIR)"
-	@mkdir -p "$(INSTALLBINDIR)"
-	@$(INSTALL) -m 0755 "$(BINARY_DIR)/$(BMT)" "$(INSTALLBINDIR)/$(BMT)"
-	@echo "OK: $(BMT), instalados em $(INSTALLBINDIR)"
+	@echo "Instalando binários em $(BIN_DIR)"
+	@mkdir -p "$(BIN_DIR)"
+	@$(INSTALL) -m 0755 "$(REPO_BIN_DIR)/$(BMT)" "$(BIN_DIR)/$(BMT)"
+	@echo "OK: $(BMT), instalados em $(BIN_DIR)"
 	@$(MAKE) --no-print-directory path-hint
 
 uninstall:
-	@echo "Removendo binários de $(INSTALLBINDIR)"
-	@rm -f "$(INSTALLBINDIR)/$(BMT)"
+	@echo "Removendo binários de $(BIN_DIR)"
+	@rm -f "$(BIN_DIR)/$(BMT)"
 	@echo "OK: removido"
 
 path-hint:
 	@echo "Adicione ao seu shell rc (bash/zsh):"
-	@echo "  export PATH=\"$(INSTALLBINDIR):\$$PATH\""
+	@echo "  export PATH=\"$(BIN_DIR):\$$PATH\""

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ curl -fsSL https://raw.githubusercontent.com/Pedro-Magalhaes/dev-metrics/main/sc
 
 ```
 
+Para instalar em um diretório personalizado, defina a variável BIN_DIR:
+```bash
+BIN_DIR=/caminho/customizado/bin curl -fsSL https://raw.githubusercontent.com/Pedro-Magalhaes/dev-metrics/main/scripts/install.sh | sh
+
+```
+
 ### Opção B: Compilação Local
 
 Se você tem o ambiente Go configurado (1.25+):
@@ -56,6 +62,14 @@ make install
 ```
 
 *Isso copiará o binário para `~/.local/bin`.*
+
+Também é possível passar um caminho customizado para a instalação do binário:
+
+```
+make install BIN_DIR=/caminho/customizado/bin
+
+
+```
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 REPO_DEFAULT="Pedro-Magalhaes/dev-metrics"
 REPO="${REPO:-$REPO_DEFAULT}"
-BINDIR="${BINDIR:-${HOME}/.local/bin}"
+BIN_DIR="${BIN_DIR:-${HOME}/.local/bin}"
 VERSION="${VERSION:-latest}"
 BIN_NAME="bmt"
 
@@ -73,7 +73,7 @@ WORKDIR="$(mktemp -d)"
 cleanup() { rm -rf "$WORKDIR"; }
 trap cleanup EXIT INT TERM
 
-mkdir -p "$BINDIR"
+mkdir -p "$BIN_DIR"
 
 # 1. Download e Verificação de Checksums
 CHECKSUMS="checksums_${TAG}.txt"
@@ -111,24 +111,24 @@ GOT="$(sha256_file "$ASSET_PATH")"
 [ "$GOT" = "$EXP" ] || fail "falha na verificação de checksum: esperado $EXP, obtido $GOT"
 
 # 4. Extração e Instalação
-printf "🚀 Instalando %s em %s...\n" "$BIN_NAME" "$BINDIR" >&2
+printf "🚀 Instalando %s em %s...\n" "$BIN_NAME" "$BIN_DIR" >&2
 tar -xzf "$ASSET_PATH" -C "$WORKDIR"
 [ -f "${WORKDIR}/${BIN_NAME}" ] || fail "binário '${BIN_NAME}' não encontrado dentro do pacote"
 
 if command -v install >/dev/null 2>&1; then
-  install -m 0755 "${WORKDIR}/${BIN_NAME}" "${BINDIR}/${BIN_NAME}"
+  install -m 0755 "${WORKDIR}/${BIN_NAME}" "${BIN_DIR}/${BIN_NAME}"
 else
-  cp "${WORKDIR}/${BIN_NAME}" "${BINDIR}/${BIN_NAME}"
-  chmod 0755 "${BINDIR}/${BIN_NAME}"
+  cp "${WORKDIR}/${BIN_NAME}" "${BIN_DIR}/${BIN_NAME}"
+  chmod 0755 "${BIN_DIR}/${BIN_NAME}"
 fi
 
 # 5. Feedback Final
 printf "\n✅ %s instalado com sucesso!\n" "$BIN_NAME" >&2
 
-if ! printf "%s" "$PATH" | grep -q "$BINDIR"; then
-  printf "\n⚠️  Atenção: %s não está no seu PATH.\n" "$BINDIR" >&2
+if ! printf "%s" "$PATH" | grep -q "$BIN_DIR"; then
+  printf "\n⚠️  Atenção: %s não está no seu PATH.\n" "$BIN_DIR" >&2
   printf "Adicione a seguinte linha ao seu ~/.bashrc ou ~/.zshrc:\n" >&2
-  printf "  export PATH=\"%s:\$PATH\"\n" "$BINDIR" >&2
+  printf "  export PATH=\"%s:\$PATH\"\n" "$BIN_DIR" >&2
 fi
 
 printf "\nExperimente rodar: %s info\n" "$BIN_NAME info" >&2


### PR DESCRIPTION
Ajusta make file para a instalação do binário único e padroniza a variável usada para sobrescrever o local de instalação default