### PR TITLE
Adiciona opções de filtro para o report

### DIFF
--- a/internal/commands/export.go
+++ b/internal/commands/export.go
@@ -27,7 +27,9 @@ func (c *ExportCommand) Run(args []string) error {
 		fs.PrintDefaults()
 		metrics.PrintResolvedLogPath(fs.Output(), "Arquivo de log: ", fs.Lookup("log").Value.String())
 	}
-	fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 
 	logPath, err := metrics.GetLogFilePath(*logOverride)
 	if err != nil {

--- a/internal/commands/report.go
+++ b/internal/commands/report.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"dev-metrics/internal/metrics"
 	"dev-metrics/internal/ui"
@@ -16,11 +17,30 @@ func (c *ReportCommand) Description() string {
 	return "Gera um relatório a partir dos dados coletados de builds"
 }
 
+func (c *ReportCommand) Usage() string {
+	return `report [--log PATH] [--since YYYY-MM-DD] [--until YYYY-MM-DD]
+
+Opções:
+  --log PATH            Caminho do arquivo de log (padrão: ./dev-metrics.log)
+  --since YYYY-MM-DD    Data de início para filtrar o relatório
+  --until YYYY-MM-DD    Data de fim para filtrar o relatório
+
+Exemplo:
+  dev-metrics report --log ./logs/dev-metrics.log --since 2024-01-01 --until 2024-01-31
+`
+}
+
 func (c *ReportCommand) Run(args []string) error {
 	// 1. Configuração e abertura de arquivo
 	fs := flag.NewFlagSet("report", flag.ContinueOnError)
 	logFlag := fs.String("log", "", "Caminho do arquivo de log")
-	fs.Parse(args)
+	sinceFlag := fs.String("since", "", "Data de início (YYYY-MM-DD) para filtrar o relatório")
+	untilFlag := fs.String("until", "", "Data de fim (YYYY-MM-DD) para filtrar o relatório")
+
+	err := fs.Parse(args)
+	if err != nil {
+		return err
+	}
 
 	logPath, err := metrics.PrintResolvedLogPath(os.Stdout, "Usando arquivo de log: ", *logFlag)
 	if err != nil {
@@ -33,7 +53,26 @@ func (c *ReportCommand) Run(args []string) error {
 	}
 	defer file.Close()
 
-	reportData, err := metrics.GenerateReport(file)
+	// Parse das opções
+	opts := metrics.ReportOptions{}
+	if *sinceFlag != "" {
+		t, err := time.ParseInLocation("2006-01-02", *sinceFlag, time.Local)
+		if err != nil {
+			return fmt.Errorf("formato de data inválido para --since (use YYYY-MM-DD): %v", err)
+		}
+		opts.Since = t
+	}
+
+	if *untilFlag != "" {
+		t, err := time.ParseInLocation("2006-01-02", *untilFlag, time.Local)
+		if err != nil {
+			return fmt.Errorf("formato de data inválido para --until (use YYYY-MM-DD): %v", err)
+		}
+		opts.Until = t
+	}
+
+	// Geração do relatório
+	reportData, err := metrics.GenerateReport(file, opts)
 	if err != nil {
 		return fmt.Errorf("Erro ao processar dados: %v", err)
 	}

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -32,7 +32,9 @@ func (c *ExecCommand) Run(args []string) error {
 		fs.PrintDefaults()
 		metrics.PrintResolvedLogPath(fs.Output(), "Arquivo de log: ", fs.Lookup("log").Value.String())
 	}
-	fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 
 	cmdArgs := fs.Args()
 

--- a/internal/metrics/paths.go
+++ b/internal/metrics/paths.go
@@ -9,6 +9,10 @@ import (
 
 const EnvLogPath = "BUILD_METRICS_LOG"
 
+// Usando monkey patching simples para facilitar testes
+var EnvGetter = os.Getenv
+var HomeDirGetter = os.UserHomeDir
+
 // GetLogFilePath retorna o caminho final baseado na prioridade:
 // 1. override (se não for vazio)
 // 2. Variável de ambiente BUILD_METRICS_LOG
@@ -18,11 +22,11 @@ func GetLogFilePath(override string) (string, error) {
 		return override, nil
 	}
 
-	if envPath := os.Getenv(EnvLogPath); envPath != "" {
+	if envPath := EnvGetter(EnvLogPath); envPath != "" {
 		return envPath, nil
 	}
 
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := HomeDirGetter()
 	if err != nil {
 		return "", err
 	}

--- a/internal/metrics/paths_test.go
+++ b/internal/metrics/paths_test.go
@@ -1,0 +1,88 @@
+package metrics_test
+
+import (
+	"dev-metrics/internal/metrics"
+	"errors"
+	"testing"
+)
+
+// Função de teste para GetLogFilePath
+func MockGetenvBuilder(returnString string) func(string) string {
+	return func(key string) string {
+		return returnString
+	}
+}
+
+// Função de teste para GetLogFilePath
+func MockHomeDirFuncBuilder(returnString string) func() (string, error) {
+	return func() (string, error) {
+		if returnString == "error" {
+			return "", errors.New("failed to get home dir")
+		}
+		return returnString, nil
+	}
+}
+
+func TestGetLogFilePath(t *testing.T) {
+	tests := []struct {
+		name       string
+		definedEnv string
+		homeDir    string
+		override   string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "Override path provided",
+			definedEnv: "/path/from/env.jsonl",
+			homeDir:    "/home",
+			override:   "/custom/path/log.jsonl",
+			want:       "/custom/path/log.jsonl",
+			wantErr:    false,
+		},
+		{
+			name:       "Environment variable path used",
+			definedEnv: "/path/from/env.jsonl",
+			homeDir:    "/home",
+			override:   "",
+			want:       "/path/from/env.jsonl",
+			wantErr:    false,
+		},
+		{
+			name:       "Default path used when no override or env var",
+			override:   "",
+			definedEnv: "",
+			homeDir:    "/home",
+			want:       "/home/.local/share/build-metrics/build_log.jsonl",
+			wantErr:    false,
+		},
+		{
+			name:       "Default path used when no override or env var",
+			override:   "",
+			definedEnv: "",
+			homeDir:    "error", // Simula erro ao obter diretório home
+			want:       "/home/.local/share/build-metrics/build_log.jsonl",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics.EnvGetter = MockGetenvBuilder(tt.definedEnv)
+			metrics.HomeDirGetter = MockHomeDirFuncBuilder(tt.homeDir)
+			got, gotErr := metrics.GetLogFilePath(tt.override)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("GetLogFilePath() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("GetLogFilePath() succeeded unexpectedly")
+			}
+
+			if got != tt.want {
+				t.Errorf("GetLogFilePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Introduced `--since` and `--until` flags for filtering report data by date.
- Enhanced error handling for command argument parsing in `Run` methods.
- Updated `GenerateReport` function to accept filtering options.
- Added unit tests for new report options and error scenarios.
- Refactored log path retrieval to support testing with mock functions.